### PR TITLE
feat: add /orchestrate command delegating to subagent-director roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ dsh plugin --profile <name> add dsh-plugin-subagent-director
   name: dsh-plugin-subagent-director
   config:
     subagentProvider: spawn      # 传输：spawn（无父上下文）/ fork（继承父历史）
-    toolName: subagent_role      # 模型可见工具名
+    toolName: subagent_role      # 本插件注册的模型可见工具名（不是内置 subagent）
     enableRunInBackground: true
     backgroundMode: one-shot     # one-shot 或 continuable
     maxDepth: 3
@@ -124,6 +124,26 @@ subagent_role({ role: "code-reviewer", model: "deepseek-chat", prompt: "..." }) 
 `role` 参数支持用角色 id 或显示名引用：未命中 id 时会按 `displayName` 精确匹配
 （多个同名角色取定义顺序第一个并提示）；建议始终用 id，见系统提示中的 Delegate 行。
 
+> **`subagent_role` 与内置 `subagent` 是两个不同的工具。** 本插件注册的是
+> `subagent_role`（工具名由 `toolName` 配置，默认 `subagent_role`）；DSH 基础
+> bundle 另有内置的 `subagent` / `subagent_fork`，两者在同一次请求的工具清单里
+> **并存**。只有走 `subagent_role` 才会应用角色 persona 与 `toolFilter`；模型改用
+> 内置 `subagent` 时这两项不生效（`applyDefaultRoute` 开启时默认模型仍会生效）。
+> 因此需要角色语义时，请在提示里明确要求调用 `subagent_role`。
+
+### 纯编排模式（`/orchestrate`）
+
+```text
+/orchestrate        # 等价于 /orchestrate on
+/orchestrate on     # 进入纯编排模式
+/orchestrate off    # 退出
+```
+
+打开后会注入一段「纯编排者」系统提示：主代理只允许通过委派工具派活，角色清单
+从当前 `subagent-director.roles` 动态渲染（无硬编码 role id），未配置角色时提示
+先去配置。该模式依赖宿主的 `commands` 与 `sessionProjections` 服务；服务缺失时
+命令会返回明确错误而不是假装成功。
+
 ## 术语
 
 - **subagentProvider（传输）**：`spawn` / `fork` / `acp`——子代理跑在哪条传输链路上；
@@ -135,7 +155,7 @@ subagent_role({ role: "code-reviewer", model: "deepseek-chat", prompt: "..." }) 
 
 ```bash
 npm install
-npm test          # vitest（129 用例）
+npm test          # vitest（226 用例）
 npm run typecheck
 npm run build     # host(tsc) + client(rolldown bundle)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dsh-plugin-subagent-director",
       "version": "0.3.0",
       "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
       "devDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
@@ -20,6 +23,7 @@
         "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
         "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
@@ -46,6 +50,7 @@
         "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-subagent": "^0.1.0-rc.8",
         "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
@@ -4371,7 +4376,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.6"
+    "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
   },
   "devDependencies": {
     "react": "^18.2.0",
@@ -105,6 +106,7 @@
     "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
     "rolldown": "^1.2.4",
     "@types/node": "^26.2.0",
     "typescript": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
     "model",
     "role-template"
   ],
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
   "license": "MIT",
   "peerDependencies": {
     "react": "^18.2.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,17 @@ export interface DirectorConfig {
    */
   subagentProvider?: string;
 
-  /** Model-facing tool name, default 'subagent_role'. Each loaded instance must use a distinct name. */
+  /**
+   * Model-facing tool name for THIS plugin's delegation tool, default
+   * 'subagent_role'. Each loaded instance must use a distinct name.
+   *
+   * Not the same tool as DSH's built-in `subagent` / `subagent_fork`: those are
+   * registered by the base bundle and coexist with this one in the same request
+   * tool catalog. Only calls that go through this name apply role persona and
+   * role `toolFilter`; a model that picks the built-in `subagent` instead gets
+   * neither (the default model route still applies when `applyDefaultRoute` is
+   * on — see below).
+   */
   toolName?: string;
 
   /** Expose `run_in_background` (default true). Disabled instances omit the argument. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { createDelegationTool } from './delegation-tool.js';
 import { CLOSE_SUBAGENT_TOOL_NAME, createCloseSubagentTool } from './close-tool.js';
 import { applyDefaultRouteSeam } from './default-route.js';
 import { applyGuidance } from './guidance.js';
+import { applyOrchestrate } from './orchestrate.js';
 import { createSettingsSnapshot, installDirectorSettings } from './settings.js';
 
 export { Config } from './config.js';
@@ -45,6 +46,18 @@ export {
   type SubagentRequestParts,
 } from './delegation-tool.js';
 export { applyGuidance, renderRolesGuidance, GUIDANCE_SECTION_ORDER, GUIDANCE_SECTION_NAME } from './guidance.js';
+export {
+  applyOrchestrate,
+  renderOrchestratorPrompt,
+  renderOrchestratorRoles,
+  buildOrchestratorFrame,
+  ORCHESTRATE_SECTION_NAME,
+  ORCHESTRATE_SECTION_ORDER,
+  ORCHESTRATE_PROJECTION_KEY,
+  ORCHESTRATE_EVENT_TYPE,
+  ORCHESTRATE_VALID_MODES,
+  type OrchestrateMode,
+} from './orchestrate.js';
 export { CLOSE_SUBAGENT_TOOL_NAME, createCloseSubagentTool } from './close-tool.js';
 export {
   SUBAGENT_DIRECTOR_SETTINGS_NAMESPACE,
@@ -57,7 +70,7 @@ export {
 
 export const name = 'subagent-director';
 
-export const inject = ['tools', 'subagents', 'llm', 'settings'];
+export const inject = ['tools', 'subagents', 'llm', 'settings', 'commands'];
 
 export function apply(ctx: Context, config: import('./config.js').DirectorConfig) {
   const backgroundMode = config.backgroundMode ?? 'one-shot';
@@ -87,6 +100,9 @@ export function apply(ctx: Context, config: import('./config.js').DirectorConfig
 
   // ---- role guidance ----------------------------------------------------
   applyGuidance(ctx, getSettings, toolName);
+
+  // ---- orchestrate command + projection + prompt section ----------------
+  applyOrchestrate(ctx, getSettings, toolName);
 
   // ---- close_subagent tool ----------------------------------------------
   // Provider-independent (drain is a global subagents operation), so it

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -121,9 +121,26 @@ export function applyOrchestrate(
     ctx.logger.warn('[orchestrate] could not register event type:', (err as Error)?.message);
   }
 
-  const projections: any = ctx.get('sessionProjections');
-  if (projections !== undefined) {
-    projections.register({
+  // Resolve sessionProjections *reactively*. At plugin apply time the host
+  // may not have mounted the sessionProjections service yet — that is the P0
+  // timing root cause: a one-shot `ctx.get` here returned undefined and
+  // silently no-op'd the projection registration, so /orchestrate never
+  // injected. Instead we register the projection the moment the service becomes
+  // available via ctx.inject, and keep `projections` in a closure so the
+  // command handler and prompt section observe it once it resolves. If the
+  // service is genuinely absent the handler (and the apply-time fallback)
+  // surface an honest error instead of a silent no-op.
+  let projections: any = undefined;
+
+  const missing = (): void =>
+    ctx.logger.warn(
+      '[orchestrate] sessionProjections service is missing on this host — the /orchestrate command will NOT take effect (no projection registered, orchestrator prompt will not inject). Provide the dsh-session-projection sessionProjections service to enable orchestrator mode.',
+    );
+
+  const registerProjection = (sp: any): void => {
+    if (projections !== undefined) return; // idempotent: inject may re-fire
+    projections = sp;
+    sp.register({
       key: ORCHESTRATE_PROJECTION_KEY,
       stateVersion: 1,
       // Wire-shape contract: the framework calls `schema.parse(view(state))` on
@@ -141,14 +158,27 @@ export function applyOrchestrate(
       view: (state: OrchestrateState) => ({ mode: state.mode }),
     });
     ctx.logger.info('[orchestrate] host active (command + projection + prompt section)');
+  };
+
+  const spNow: any = ctx.get('sessionProjections');
+  if (spNow !== undefined) {
+    registerProjection(spNow);
+  } else if (typeof (ctx as any).inject === 'function') {
+    // Reactive path: register once the host mounts sessionProjections. The
+    // callback only runs when the dependency is present, so this also covers
+    // the "ready slightly later" case that the one-shot get missed. If the
+    // service never appears, the handler below returns an honest error — no
+    // silent no-op.
+    const fiber = (ctx as any).inject(['sessionProjections'], (injectedCtx: Context) => {
+      registerProjection(injectedCtx.get('sessionProjections'));
+    });
+    if (fiber && typeof (fiber as any).dispose === 'function') {
+      ctx.effect(() => (fiber as any).dispose(), 'subagent-director:orchestrate-projection-inject');
+    }
   } else {
-    // Loud failure (P0 silent-degradation fix): without sessionProjections the
-    // projection can never be registered, so /orchestrate is a silent no-op.
-    // Surface it instead of letting /orchestrate on claim success while nothing
-    // actually takes effect.
-    ctx.logger.warn(
-      '[orchestrate] sessionProjections service is missing on this host — the /orchestrate command will NOT take effect (no projection registered, orchestrator prompt will not inject). Provide the dsh-session-projection sessionProjections service to enable orchestrator mode.',
-    );
+    // No reactive mechanism available and the service is absent now: surface
+    // the missing service loudly (P0 honest-degradation guard).
+    missing();
   }
 
   const commands: any = ctx.get('commands');
@@ -166,6 +196,10 @@ export function applyOrchestrate(
         // /orchestrate cannot take effect. Refuse with an honest message
         // instead of falsely reporting success (P0 silent-degradation fix).
         if (projections === undefined) {
+          // Service never became available (truly absent host): refuse with an
+          // honest message and warn, instead of falsely reporting success (P0
+          // silent-degradation fix).
+          missing();
           return {
             kind: 'error',
             text:

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -140,6 +140,15 @@ export function applyOrchestrate(
       },
       view: (state: OrchestrateState) => ({ mode: state.mode }),
     });
+    ctx.logger.info('[orchestrate] host active (command + projection + prompt section)');
+  } else {
+    // Loud failure (P0 silent-degradation fix): without sessionProjections the
+    // projection can never be registered, so /orchestrate is a silent no-op.
+    // Surface it instead of letting /orchestrate on claim success while nothing
+    // actually takes effect.
+    ctx.logger.warn(
+      '[orchestrate] sessionProjections service is missing on this host — the /orchestrate command will NOT take effect (no projection registered, orchestrator prompt will not inject). Provide the dsh-session-projection sessionProjections service to enable orchestrator mode.',
+    );
   }
 
   const commands: any = ctx.get('commands');
@@ -152,6 +161,17 @@ export function applyOrchestrate(
         const mode = (invocation.rawInput || '').trim().toLowerCase() || 'on';
         if (!ORCHESTRATE_VALID_MODES.includes(mode as OrchestrateMode)) {
           return { kind: 'error', text: `Invalid: "${invocation.rawInput}". Valid: on|off` };
+        }
+        // Without sessionProjections the projection is never registered, so
+        // /orchestrate cannot take effect. Refuse with an honest message
+        // instead of falsely reporting success (P0 silent-degradation fix).
+        if (projections === undefined) {
+          return {
+            kind: 'error',
+            text:
+              `Orchestrator mode "${mode}" was NOT applied: the sessionProjections service is missing on this host, so /orchestrate has no effect and the orchestrator prompt will not inject. ` +
+              `Provide the dsh-session-projection sessionProjections service to enable orchestrator mode.`,
+          };
         }
         invocation.agent.session.append(ORCHESTRATE_EVENT_TYPE, { mode });
         return { kind: 'success', text: mode === 'off' ? 'Orchestrator mode: off' : 'Orchestrator mode: on' };
@@ -184,6 +204,5 @@ export function applyOrchestrate(
       },
     });
   }
-
-  ctx.logger.info('[orchestrate] host active (command + projection + prompt section)');
 }
+

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -5,7 +5,15 @@
  * Adds a `/orchestrate on|off` slash command that flips a per-session
  * projection and, when on, injects a pure-orchestrator system-prompt section.
  * The orchestrator delegates exclusively through the subagent-director
- * delegation tool (`subagent_role` by default).
+ * delegation tool, whose model-facing name is `config.toolName` (default
+ * `subagent_role`) and is threaded in here as `toolName`.
+ *
+ * Naming caveat (observed on a live rc.8 web host): the assembled tool catalog
+ * contains BOTH this plugin's `subagent_role` and the base bundle's built-in
+ * `subagent` / `subagent_fork`. They are distinct tools, not two names for one
+ * wire entry. The prompt below names `toolName` explicitly precisely because a
+ * model that reaches for the built-in `subagent` bypasses role persona and role
+ * toolFilter.
  *
  * The role list rendered into the prompt is derived dynamically from the live
  * plugin settings (`subagent-director.roles`) — the same source `guidance.ts`

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -143,11 +143,15 @@ export function applyOrchestrate(
     sp.register({
       key: ORCHESTRATE_PROJECTION_KEY,
       stateVersion: 1,
-      // Wire-shape contract: the framework calls `schema.parse(view(state))` on
-      // every snapshot (see dsh-session-projection SessionProjectionRegistry).
-      // Omitting it throws at snapshot time — which the section's read used to
-      // swallow silently, so /orchestrate on never injected. Keep it.
-      schema: z.object({ mode: z.enum(ORCHESTRATE_VALID_MODES) }),
+      // Real @deepseek-ai/dsh-session-projection contract (SessionProjectionRegistry):
+      // `stateSchema` validates host state (persisted-cache restore path); a
+      // client-visible unit MUST declare `wire: { viewSchema, view }` or
+      // `snapshot()` SKIPS it entirely (`if (def.wire === undefined) continue`),
+      // so `snapshot().values['orchestrate']` is never populated and the prompt
+      // section always reads undefined → no injection. The prior `schema` + bare
+      // `view` made this a host-only unit — the actual root cause of the
+      // on==off byte-identical system prompts. Fix: declare both correctly.
+      stateSchema: z.object({ mode: z.enum(ORCHESTRATE_VALID_MODES) }),
       init: (): OrchestrateState => ({ mode: 'off' }),
       apply: (state: OrchestrateState, event: any): OrchestrateState => {
         if (!event || event.type !== ORCHESTRATE_EVENT_TYPE) return state;
@@ -155,7 +159,10 @@ export function applyOrchestrate(
         if (!ORCHESTRATE_VALID_MODES.includes(mode as OrchestrateMode) || state.mode === mode) return state;
         return { mode: mode as OrchestrateMode };
       },
-      view: (state: OrchestrateState) => ({ mode: state.mode }),
+      wire: {
+        viewSchema: z.object({ mode: z.enum(ORCHESTRATE_VALID_MODES) }),
+        view: (state: OrchestrateState) => ({ mode: state.mode }),
+      },
     });
     ctx.logger.info('[orchestrate] host active (command + projection + prompt section)');
   };

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -1,0 +1,178 @@
+/**
+ * Orchestrate command for Subagent Director (merged from the standalone
+ * `orchestrate` plugin).
+ *
+ * Adds a `/orchestrate on|off` slash command that flips a per-session
+ * projection and, when on, injects a pure-orchestrator system-prompt section.
+ * The orchestrator delegates exclusively through the subagent-director
+ * delegation tool (`subagent_role` by default).
+ *
+ * The role list rendered into the prompt is derived dynamically from the live
+ * plugin settings (`subagent-director.roles`) — the same source `guidance.ts`
+ * reads — so it never hard-codes role ids and stays correct when the operator
+ * reconfigures roles. When no roles are configured the prompt tells the user
+ * to configure them rather than silently emitting an empty section.
+ *
+ * Service posture mirrors `guidance.ts`: `commands`, `sessionProjections` and
+ * `systemPrompt` are optional host-plane rows acquired through `ctx.get` with
+ * `undefined` guards, so the wiring no-ops cleanly on surfaces that lack them.
+ */
+import type { Context } from '@deepseek-ai/cordis';
+import { KNOWN_SESSION_EVENT_TYPES } from '@deepseek-ai/dsh-session';
+
+import type { SubagentDirectorSettings } from './settings.js';
+
+/** Stable system-prompt section name. */
+export const ORCHESTRATE_SECTION_NAME = 'orchestrate-mode';
+
+/** Prompt order: sits low (55) so the orchestrator contract is near the top. */
+export const ORCHESTRATE_SECTION_ORDER = 55;
+
+/** Per-session projection key holding the orchestrator on/off state. */
+export const ORCHESTRATE_PROJECTION_KEY = 'orchestrate';
+
+/** Session event type emitted when the mode changes. */
+export const ORCHESTRATE_EVENT_TYPE = 'orchestrate/change';
+
+/** Accepted mode values. */
+export const ORCHESTRATE_VALID_MODES = ['on', 'off'] as const;
+export type OrchestrateMode = (typeof ORCHESTRATE_VALID_MODES)[number];
+
+interface OrchestrateState {
+  mode: OrchestrateMode;
+}
+
+/**
+ * Build the data-independent framing of the orchestrator prompt for a given
+ * delegation tool name. The role list is appended separately by
+ * {@link renderOrchestratorRoles}.
+ * @param toolName - the configured model-facing delegation tool name.
+ */
+export function buildOrchestratorFrame(toolName: string): string {
+  return `You are a PURE ORCHESTRATOR. Your only action is to call the \`${toolName}\` tool (provided by the subagent-director plugin) to delegate work. You must NEVER read, write, edit, grep, find, or execute anything yourself.
+
+The subagent-director plugin supplies its role templates from settings (subagent-director.roles) and the guidance section 'subagent-director:roles'. Delegate exactly one task per call:
+
+    ${toolName}({ role: '<role-id>', prompt: '<self-contained task>', description: '<what this delegation produces>' })`;
+}
+
+/**
+ * Render the role list portion of the orchestrator prompt from the live
+ * settings. Returns a "configure roles first" notice when no roles exist so
+ * the operator is told what to do instead of receiving a blank contract.
+ * @param settings - current resolved settings snapshot.
+ * @param toolName - the configured model-facing delegation tool name.
+ */
+export function renderOrchestratorRoles(settings: SubagentDirectorSettings, toolName: string): string {
+  const roles = settings.roles ?? {};
+  const entries = Object.entries(roles).filter(([, role]) => role !== undefined);
+  if (entries.length === 0) {
+    return 'No Subagent Director roles are configured yet. Configure `subagent-director.roles` (settings.yaml or the settings panel) before entering orchestrator mode — the orchestrator can only delegate to defined roles.';
+  }
+
+  const lines = [
+    `Delegate work by calling the \`${toolName}\` tool with a role id from the list below. Reference roles by their id (shown), never by display name, and never invent a role id that is not listed:`,
+  ];
+  for (const [id, role] of entries) {
+    lines.push(`- ${role.displayName || id}: ${role.description}`);
+    lines.push(`    ${toolName}({ role: "${id}", prompt: "..." })`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Assemble the full orchestrator prompt (framing + dynamic role list).
+ * @param settings - current resolved settings snapshot.
+ * @param toolName - the configured model-facing delegation tool name.
+ */
+export function renderOrchestratorPrompt(settings: SubagentDirectorSettings, toolName: string): string {
+  return `${buildOrchestratorFrame(toolName)}\n\n${renderOrchestratorRoles(settings, toolName)}\n\nOrchestration rules:
+1. Only dispatch. Forbid doing the work yourself.
+2. Independent tasks -> dispatch them in parallel (multiple ${toolName} calls in one turn).
+3. Dependent / relay tasks -> wait for the prior subagent to finish, then dispatch the next stage.
+4. Every subagent prompt must be self-contained: goal, constraints, output format, acceptance criteria. Subagents receive NO parent context.
+5. If the user's request names a specific role, dispatch to that role id. If a display name is given, map it to its id. If no role is named, dispatch to the role whose display name indicates coordination (e.g. contains 协调 / Orchestrator / Coordinator); when no such role exists, dispatch to the first configured role and let it decompose and coordinate.
+6. Unclear dependencies or missing information -> ask the USER, never guess.
+7. For independent fan-out you may set run_in_background: true and collect results later; for relay steps set run_in_background: false so you wait for the result before dispatching the next stage.
+8. Finish only when every subagent has completed. Then output a summary report: who produced what, and remaining todos.`;
+}
+
+/**
+ * Wire the `/orchestrate` command, its session projection, and the
+ * orchestrator prompt section into the host. Each host-plane service is
+ * acquired lazily and guarded, so a missing service degrades to a no-op.
+ * @param ctx - plugin context.
+ * @param getSettings - returns the current settings snapshot.
+ * @param toolName - the configured model-facing delegation tool name.
+ */
+export function applyOrchestrate(
+  ctx: Context,
+  getSettings: () => SubagentDirectorSettings,
+  toolName: string,
+): void {
+  // Register our event type on the shared KNOWN set so session logs carrying
+  // `orchestrate/change` load in any boot that mounts this plugin.
+  // The shared set is a mutable Set at runtime; its exported type is
+  // ReadonlySet, so we widen to Set<string> for the add call.
+  try {
+    (KNOWN_SESSION_EVENT_TYPES as Set<string>).add(ORCHESTRATE_EVENT_TYPE);
+  } catch (err) {
+    ctx.logger.warn('[orchestrate] could not register event type:', (err as Error)?.message);
+  }
+
+  const projections: any = ctx.get('sessionProjections');
+  if (projections !== undefined) {
+    projections.register({
+      key: ORCHESTRATE_PROJECTION_KEY,
+      stateVersion: 1,
+      init: (): OrchestrateState => ({ mode: 'off' }),
+      apply: (state: OrchestrateState, event: any): OrchestrateState => {
+        if (!event || event.type !== ORCHESTRATE_EVENT_TYPE) return state;
+        const mode = event.data && typeof event.data.mode === 'string' ? event.data.mode : '';
+        if (!ORCHESTRATE_VALID_MODES.includes(mode as OrchestrateMode) || state.mode === mode) return state;
+        return { mode: mode as OrchestrateMode };
+      },
+      view: (state: OrchestrateState) => ({ mode: state.mode }),
+    });
+  }
+
+  const commands: any = ctx.get('commands');
+  if (commands !== undefined) {
+    commands.register({
+      name: 'orchestrate',
+      description: 'Enter pure-orchestrator mode — delegate all work to the subagent-director team.',
+      input: { hint: 'on|off' },
+      handler: (invocation: any) => {
+        const mode = (invocation.rawInput || '').trim().toLowerCase() || 'on';
+        if (!ORCHESTRATE_VALID_MODES.includes(mode as OrchestrateMode)) {
+          return { kind: 'error', text: `Invalid: "${invocation.rawInput}". Valid: on|off` };
+        }
+        invocation.agent.session.append(ORCHESTRATE_EVENT_TYPE, { mode });
+        return { kind: 'success', text: mode === 'off' ? 'Orchestrator mode: off' : 'Orchestrator mode: on' };
+      },
+    });
+  }
+
+  const systemPrompt: any = ctx.get('systemPrompt');
+  if (systemPrompt !== undefined) {
+    systemPrompt.section({
+      name: ORCHESTRATE_SECTION_NAME,
+      order: ORCHESTRATE_SECTION_ORDER,
+      text: (context: any) => {
+        const agent = context && context.agent;
+        if (!agent || projections === undefined) return '';
+        let mode: OrchestrateMode = 'off';
+        try {
+          const value = projections.snapshot(agent.session).values[ORCHESTRATE_PROJECTION_KEY];
+          if (value && typeof value.mode === 'string') mode = value.mode as OrchestrateMode;
+        } catch {
+          mode = 'off';
+        }
+        if (mode === 'off') return '';
+        return renderOrchestratorPrompt(getSettings(), toolName);
+      },
+    });
+  }
+
+  ctx.logger.info('[orchestrate] host active (command + projection + prompt section)');
+}

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -18,6 +18,7 @@
  * `undefined` guards, so the wiring no-ops cleanly on surfaces that lack them.
  */
 import type { Context } from '@deepseek-ai/cordis';
+import { z } from 'zod';
 import { KNOWN_SESSION_EVENT_TYPES } from '@deepseek-ai/dsh-session';
 
 import type { SubagentDirectorSettings } from './settings.js';
@@ -125,6 +126,11 @@ export function applyOrchestrate(
     projections.register({
       key: ORCHESTRATE_PROJECTION_KEY,
       stateVersion: 1,
+      // Wire-shape contract: the framework calls `schema.parse(view(state))` on
+      // every snapshot (see dsh-session-projection SessionProjectionRegistry).
+      // Omitting it throws at snapshot time — which the section's read used to
+      // swallow silently, so /orchestrate on never injected. Keep it.
+      schema: z.object({ mode: z.enum(ORCHESTRATE_VALID_MODES) }),
       init: (): OrchestrateState => ({ mode: 'off' }),
       apply: (state: OrchestrateState, event: any): OrchestrateState => {
         if (!event || event.type !== ORCHESTRATE_EVENT_TYPE) return state;
@@ -140,8 +146,8 @@ export function applyOrchestrate(
   if (commands !== undefined) {
     commands.register({
       name: 'orchestrate',
-      description: 'Enter pure-orchestrator mode — delegate all work to the subagent-director team.',
-      input: { hint: 'on|off' },
+      description: 'Enter pure-orchestrator mode — delegate all work to the subagent-director team. No args defaults to "on".',
+      input: { hint: 'on|off (no args = on)' },
       handler: (invocation: any) => {
         const mode = (invocation.rawInput || '').trim().toLowerCase() || 'on';
         if (!ORCHESTRATE_VALID_MODES.includes(mode as OrchestrateMode)) {
@@ -159,13 +165,18 @@ export function applyOrchestrate(
       name: ORCHESTRATE_SECTION_NAME,
       order: ORCHESTRATE_SECTION_ORDER,
       text: (context: any) => {
-        const agent = context && context.agent;
-        if (!agent || projections === undefined) return '';
+        // Host passes the assembly context (AssembleContext) with `agent` set
+        // at runtime (see dsh-agent assembleContextFor). Some hosts may instead
+        // hand `session` directly, so accept either shape (D2).
+        const session = context?.session || context?.agent?.session;
+        if (!session || projections === undefined) return '';
         let mode: OrchestrateMode = 'off';
         try {
-          const value = projections.snapshot(agent.session).values[ORCHESTRATE_PROJECTION_KEY];
+          const value = projections.snapshot(session).values[ORCHESTRATE_PROJECTION_KEY];
           if (value && typeof value.mode === 'string') mode = value.mode as OrchestrateMode;
-        } catch {
+        } catch (err) {
+          // Surface the failure instead of silently dropping the prompt (D1).
+          ctx.logger.warn('[orchestrate] could not read orchestrator mode from projection:', (err as Error)?.message);
           mode = 'off';
         }
         if (mode === 'off') return '';

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -21,9 +21,12 @@
  * reconfigures roles. When no roles are configured the prompt tells the user
  * to configure them rather than silently emitting an empty section.
  *
- * Service posture mirrors `guidance.ts`: `commands`, `sessionProjections` and
- * `systemPrompt` are optional host-plane rows acquired through `ctx.get` with
- * `undefined` guards, so the wiring no-ops cleanly on surfaces that lack them.
+ * Service posture mirrors `guidance.ts`: `commands` and `sessionProjections` are
+ * acquired reactively through `ctx.inject` (so the `/orchestrate` command and the
+ * projection register as soon as the host service is ready, even if it mounts
+ * slightly after `apply`), while `systemPrompt` is still read lazily via
+ * `ctx.get`. A host that never provides `sessionProjections` degrades to an
+ * honest error from the command handler rather than a silent no-op.
  */
 import type { Context } from '@deepseek-ai/cordis';
 import { z } from 'zod';
@@ -196,36 +199,52 @@ export function applyOrchestrate(
     missing();
   }
 
-  const commands: any = ctx.get('commands');
-  if (commands !== undefined) {
-    commands.register({
-      name: 'orchestrate',
-      description: 'Enter pure-orchestrator mode — delegate all work to the subagent-director team. No args defaults to "on".',
-      input: { hint: 'on|off (no args = on)' },
-      handler: (invocation: any) => {
-        const mode = (invocation.rawInput || '').trim().toLowerCase() || 'on';
-        if (!ORCHESTRATE_VALID_MODES.includes(mode as OrchestrateMode)) {
-          return { kind: 'error', text: `Invalid: "${invocation.rawInput}". Valid: on|off` };
-        }
-        // Without sessionProjections the projection is never registered, so
-        // /orchestrate cannot take effect. Refuse with an honest message
-        // instead of falsely reporting success (P0 silent-degradation fix).
-        if (projections === undefined) {
-          // Service never became available (truly absent host): refuse with an
-          // honest message and warn, instead of falsely reporting success (P0
-          // silent-degradation fix).
-          missing();
-          return {
-            kind: 'error',
-            text:
-              `Orchestrator mode "${mode}" was NOT applied: the sessionProjections service is missing on this host, so /orchestrate has no effect and the orchestrator prompt will not inject. ` +
-              `Provide the dsh-session-projection sessionProjections service to enable orchestrator mode.`,
-          };
-        }
-        invocation.agent.session.append(ORCHESTRATE_EVENT_TYPE, { mode });
-        return { kind: 'success', text: mode === 'off' ? 'Orchestrator mode: off' : 'Orchestrator mode: on' };
-      },
-    });
+  // Register the `/orchestrate` slash command *reactively*: the host's `commands`
+  // service is declared in this plugin's `inject` (so cordis guarantees it is
+  // present before `apply` runs), but we still register through `ctx.inject`
+  // to mirror the sessionProjections fix and the dsh-plan-mode precedent — a
+  // one-shot `ctx.get('commands')` guard is dead code once the dependency is
+  // declared, and cannot recover from a host that mounts `commands` slightly
+  // after `apply`. The handler reads `projections` from the closure, so command
+  // availability and projection availability are decoupled: the handler still
+  // refuses honestly (with a warning) if the projection service never came up.
+  const cmdFiber =
+    typeof (ctx as any).inject === 'function'
+      ? (ctx as any).inject(['commands'], (injectedCtx: Context) => {
+          const commands: any = injectedCtx.get('commands');
+          commands.register({
+            name: 'orchestrate',
+            description: 'Enter pure-orchestrator mode — delegate all work to the subagent-director team. No args defaults to "on".',
+            input: { hint: 'on|off (no args = on)' },
+            handler: (invocation: any) => {
+              const mode = (invocation.rawInput || '').trim().toLowerCase() || 'on';
+              if (!ORCHESTRATE_VALID_MODES.includes(mode as OrchestrateMode)) {
+                return { kind: 'error', text: `Invalid: "${invocation.rawInput}". Valid: on|off` };
+              }
+              // Without sessionProjections the projection is never registered, so
+              // /orchestrate cannot take effect. Refuse with an honest message
+              // instead of falsely reporting success (P0 silent-degradation fix).
+              if (projections === undefined) {
+                // Service never became available (truly absent host): refuse with an
+                // honest message and warn, instead of falsely reporting success (P0
+                // silent-degradation fix).
+                missing();
+                return {
+                  kind: 'error',
+                  text:
+                    `Orchestrator mode "${mode}" was NOT applied: the sessionProjections service is missing on this host, so /orchestrate has no effect and the orchestrator prompt will not inject. ` +
+                    `Provide the dsh-session-projection sessionProjections service to enable orchestrator mode.`,
+                };
+              }
+              invocation.agent.session.append(ORCHESTRATE_EVENT_TYPE, { mode });
+              return { kind: 'success', text: mode === 'off' ? 'Orchestrator mode: off' : 'Orchestrator mode: on' };
+            },
+          });
+        })
+      : undefined;
+
+  if (cmdFiber && typeof (cmdFiber as any).dispose === 'function') {
+    ctx.effect(() => (cmdFiber as any).dispose(), 'subagent-director:orchestrate-command-inject');
   }
 
   const systemPrompt: any = ctx.get('systemPrompt');

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -219,21 +219,76 @@ export function applyOrchestrate(
       name: ORCHESTRATE_SECTION_NAME,
       order: ORCHESTRATE_SECTION_ORDER,
       text: (context: any) => {
-        // Host passes the assembly context (AssembleContext) with `agent` set
-        // at runtime (see dsh-agent assembleContextFor). Some hosts may instead
-        // hand `session` directly, so accept either shape (D2).
-        const session = context?.session || context?.agent?.session;
-        if (!session || projections === undefined) return '';
-        let mode: OrchestrateMode = 'off';
-        try {
-          const value = projections.snapshot(session).values[ORCHESTRATE_PROJECTION_KEY];
-          if (value && typeof value.mode === 'string') mode = value.mode as OrchestrateMode;
-        } catch (err) {
-          // Surface the failure instead of silently dropping the prompt (D1).
-          ctx.logger.warn('[orchestrate] could not read orchestrator mode from projection:', (err as Error)?.message);
-          mode = 'off';
+        // Root-cause note (P0 render-time silent no-op, sibling of C1):
+        // @deepseek-ai/dsh-session-projection's read face keys its per-session
+        // watermark cache by the SESSION OBJECT via a WeakMap and folds
+        // `session.events` (see cellFor/buildCell in the package's lib/index.js).
+        // A snapshot therefore reads the mode ONLY from the live Session object
+        // whose `.events` log carries the `orchestrate/change` event that the
+        // /orchestrate command appended. If the assembly context hands a
+        // DIFFERENT session reference (e.g. a request wrapper instead of the
+        // agent's own session), the cell is rebuilt from an empty log and
+        // silently returns 'off', dropping the section. We must hand the
+        // canonical session object — and try every session reference the
+        // context exposes so a stray wrapper reference cannot downgrade us.
+        const sessionCandidates: any[] = [];
+        if (context?.agent?.session) sessionCandidates.push(context.agent.session);
+        if (context?.session && context.session !== context?.agent?.session) {
+          sessionCandidates.push(context.session);
         }
-        if (mode === 'off') return '';
+
+        if (sessionCandidates.length === 0) {
+          // No resolvable session — cannot read the projection. Warn instead of
+          // silently dropping (P0 honest-degradation; do not return '' silently).
+          ctx.logger.warn(
+            '[orchestrate] system-prompt section invoked without a resolvable session (both context.agent.session and context.session are absent) — orchestrator-mode section skipped. Possible cause: the assembly context shape differs from the dsh-agent AssembleContext contract.',
+          );
+          return '';
+        }
+        // P0 missing-service path: the service never mounted. The apply-time
+        // missing() already emitted the loud warning, so only the section is
+        // skipped here (no per-assembly re-warning).
+        if (projections === undefined) return '';
+
+        let resolvedMode: OrchestrateMode | undefined;
+        let sawError = false;
+        for (const candidate of sessionCandidates) {
+          try {
+            const snap = projections.snapshot(candidate);
+            const value = snap?.values?.[ORCHESTRATE_PROJECTION_KEY];
+            if (value && typeof value.mode === 'string') {
+              const m = value.mode as OrchestrateMode;
+              // 'on' wins immediately; otherwise remember the first known value.
+              if (m === 'on') {
+                resolvedMode = 'on';
+                break;
+              }
+              if (resolvedMode === undefined) resolvedMode = m;
+            }
+          } catch (err) {
+            // Surface instead of silently dropping (D1). The most likely cause
+            // is a session-identity mismatch: this candidate is not the object
+            // the /orchestrate command wrote the orchestrate/change event to.
+            sawError = true;
+            ctx.logger.warn(
+              '[orchestrate] could not read orchestrator mode from projection for a candidate session (session identity may not match the session /orchestrate on wrote to):',
+              (err as Error)?.message,
+            );
+          }
+        }
+
+        if (resolvedMode === undefined) {
+          // Could not resolve any mode from any candidate session. Warn with the
+          // likely cause; do NOT silently pretend 'off'.
+          if (!sawError) {
+            ctx.logger.warn(
+              '[orchestrate] orchestrator mode could not be resolved from any candidate session — orchestrator-mode section skipped. Possible cause: the assembly context session identity does not match the session the /orchestrate command wrote the orchestrate/change event to (the projection cache is keyed by the live Session object, per @deepseek-ai/dsh-session-projection).',
+            );
+          }
+          return '';
+        }
+        // Legitimate off: no section, no warning (intended behavior).
+        if (resolvedMode === 'off') return '';
         return renderOrchestratorPrompt(getSettings(), toolName);
       },
     });

--- a/test/orchestrate-wiring.test.ts
+++ b/test/orchestrate-wiring.test.ts
@@ -29,7 +29,7 @@ const settings = {
 const getSettings = () => settings;
 const toolName = 'subagent_role';
 
-function makeFakeCtx() {
+function makeFakeCtx(opts: { withoutProjections?: boolean } = {}) {
   const state = { mode: 'off' as string, throws: false };
   const registeredSections: any[] = [];
   const registeredCommands: any[] = [];
@@ -61,6 +61,15 @@ function makeFakeCtx() {
   const ctx: any = {
     logger,
     get(name: string) {
+      if (opts.withoutProjections) {
+        // Simulate a host that does not provide the sessionProjections
+        // service (P0 silent-degradation path): commands/systemPrompt may
+        // still exist, but sessionProjections is absent.
+        if (name === 'sessionProjections') return undefined;
+        if (name === 'systemPrompt') return systemPrompt;
+        if (name === 'commands') return commands;
+        return undefined;
+      }
       if (name === 'sessionProjections') return sessionProjections;
       if (name === 'systemPrompt') return systemPrompt;
       if (name === 'commands') return commands;
@@ -173,6 +182,35 @@ describe('applyOrchestrate — command handler', () => {
     const bad = handler({ rawInput: 'maybe', agent: { session: { append: () => {} } } });
     expect(bad.kind).toBe('error');
     expect(bad.text).toContain('Valid: on|off');
+  });
+});
+
+describe('applyOrchestrate — missing sessionProjections service (P0)', () => {
+  it('logs a loud warning when sessionProjections is missing', () => {
+    const { ctx, logger } = makeFakeCtx({ withoutProjections: true });
+    applyOrchestrate(ctx, getSettings, toolName);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const msg = String(logger.warn.mock.calls[0][0]);
+    expect(msg).toContain('sessionProjections');
+    expect(msg).toMatch(/orchestrate|will NOT take effect|not take effect/i);
+  });
+
+  it('does NOT falsely report success for /orchestrate on when the service is missing', () => {
+    const { ctx, registeredCommands } = makeFakeCtx({ withoutProjections: true });
+    applyOrchestrate(ctx, getSettings, toolName);
+    const handler = registeredCommands[0].handler;
+    const res = handler({ rawInput: 'on', agent: { session: { append: () => {} } } });
+    expect(res.text).not.toContain('Orchestrator mode: on');
+    expect(res.text).toMatch(/NOT applied|will NOT take effect|missing|not take effect/i);
+  });
+
+  it('warns for the off path too when the service is missing', () => {
+    const { ctx, registeredCommands } = makeFakeCtx({ withoutProjections: true });
+    applyOrchestrate(ctx, getSettings, toolName);
+    const handler = registeredCommands[0].handler;
+    const res = handler({ rawInput: 'off', agent: { session: { append: () => {} } } });
+    expect(res.text).not.toContain('Orchestrator mode: off');
+    expect(res.text).toMatch(/NOT applied|will NOT take effect|missing|not take effect/i);
   });
 });
 

--- a/test/orchestrate-wiring.test.ts
+++ b/test/orchestrate-wiring.test.ts
@@ -22,6 +22,7 @@ import {
   ORCHESTRATE_PROJECTION_KEY,
   ORCHESTRATE_EVENT_TYPE,
 } from '../src/orchestrate.js';
+import { inject as pluginInject, name as pluginName } from '../src/index.js';
 import { KNOWN_SESSION_EVENT_TYPES } from '@deepseek-ai/dsh-session';
 
 const settings = {
@@ -30,11 +31,21 @@ const settings = {
 const getSettings = () => settings;
 const toolName = 'subagent_role';
 
-function makeFakeCtx(opts: { withoutProjections?: boolean; identityKeyed?: boolean } = {}) {
+function makeFakeCtx(opts: { withoutProjections?: boolean; identityKeyed?: boolean; withoutCommands?: boolean } = {}) {
   const state = { mode: 'off' as string, throws: false };
   const registeredSections: any[] = [];
   const registeredCommands: any[] = [];
   let projectionDef: any = undefined;
+  // When `withoutCommands` is set, the host does NOT provide the `commands`
+  // service at apply time; it can be mounted later via `mountCommands()` to
+  // exercise the reactive (ctx.inject) registration path.
+  let commandsMounted = !opts.withoutCommands;
+  const pendingInjects: { deps: string[]; cb: (ctx: any) => void }[] = [];
+  const mountCommands = () => {
+    commandsMounted = true;
+    const pending = pendingInjects.splice(0, pendingInjects.length);
+    pending.forEach((p) => p.cb(ctx));
+  };
   // Mirrors @deepseek-ai/dsh-session-projection's real WeakMap keyed by the
   // session OBJECT (cellFor reads registration.cells.get(session) and folds
   // session.events). When identityKeyed, snapshot() resolves the mode from the
@@ -92,20 +103,31 @@ function makeFakeCtx(opts: { withoutProjections?: boolean; identityKeyed?: boole
   const ctx: any = {
     logger,
     get(name: string) {
+      if (name === 'commands') return commandsMounted ? commands : undefined;
       if (opts.withoutProjections) {
         // Simulate a host that does not provide the sessionProjections
         // service (P0 silent-degradation path): commands/systemPrompt may
         // still exist, but sessionProjections is absent.
         if (name === 'sessionProjections') return undefined;
         if (name === 'systemPrompt') return systemPrompt;
-        if (name === 'commands') return commands;
         return undefined;
       }
       if (name === 'sessionProjections') return sessionProjections;
       if (name === 'systemPrompt') return systemPrompt;
-      if (name === 'commands') return commands;
       return undefined;
     },
+    inject(deps: string[], cb: (ctx: any) => void) {
+      // Faithful cordis ctx.inject contract: fire immediately when every dep
+      // is resolvable; otherwise defer (capture) until the host mounts it.
+      if (deps.every((d) => ctx.get(d) !== undefined)) {
+        cb(ctx);
+      } else {
+        pendingInjects.push({ deps, cb });
+      }
+      return { dispose: () => {} };
+    },
+    // No-op effect: test fakes don't need real lifecycle tracking.
+    effect: () => () => {},
   };
   return {
     ctx,
@@ -115,6 +137,7 @@ function makeFakeCtx(opts: { withoutProjections?: boolean; identityKeyed?: boole
     sessionProjections,
     state,
     logger,
+    mountCommands,
   };
 }
 
@@ -288,13 +311,18 @@ describe('applyOrchestrate — command handler', () => {
 });
 
 describe('applyOrchestrate — missing sessionProjections service (P0)', () => {
-  it('logs a loud warning when sessionProjections is missing', () => {
-    const { ctx, logger } = makeFakeCtx({ withoutProjections: true });
+  it('surfaces an honest error (with warning) when /orchestrate is used without sessionProjections', () => {
+    const { ctx, registeredCommands, logger } = makeFakeCtx({ withoutProjections: true });
     applyOrchestrate(ctx, getSettings, toolName);
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    const msg = String(logger.warn.mock.calls[0][0]);
+    // The command still registers (commands service is present on this host).
+    expect(registeredCommands[0]).toBeDefined();
+    const res = registeredCommands[0].handler({ rawInput: 'on', agent: { session: { append: () => {} } } });
+    expect(res.kind).toBe('error');
+    expect(res.text).toMatch(/NOT applied|will NOT take effect|missing|not take effect/i);
+    // The honest-degradation warning fires when the command is actually used.
+    expect(logger.warn).toHaveBeenCalled();
+    const msg = String(logger.warn.mock.calls.at(-1)?.[0]);
     expect(msg).toContain('sessionProjections');
-    expect(msg).toMatch(/orchestrate|will NOT take effect|not take effect/i);
   });
 
   it('does NOT falsely report success for /orchestrate on when the service is missing', () => {
@@ -337,6 +365,7 @@ describe('applyOrchestrate — reactive (deferred) sessionProjections (P0 timing
     let projectionDef: any = undefined;
     let mounted = false;
     let injectCb: ((ctx: any) => void) | undefined;
+    const pending: ((ctx: any) => void)[] = [];
 
     const sessionProjections = {
       register(def: any) {
@@ -363,8 +392,13 @@ describe('applyOrchestrate — reactive (deferred) sessionProjections (P0 timing
         return undefined;
       },
       inject(_deps: string[], cb: (ctx: any) => void) {
-        injectCb = cb;
-        return { dispose: () => { injectCb = undefined; } };
+        // Faithful cordis contract: fire immediately when resolvable, else defer.
+        if (_deps.every((d) => ctx.get(d) !== undefined)) {
+          cb(ctx);
+        } else {
+          pending.push(cb);
+        }
+        return { dispose: () => {} };
       },
       effect: () => () => {},
     };
@@ -378,7 +412,8 @@ describe('applyOrchestrate — reactive (deferred) sessionProjections (P0 timing
       // Simulate the host mounting the service after apply time.
       mountSessionProjections: () => {
         mounted = true;
-        injectCb?.(ctx);
+        const toFire = pending.splice(0, pending.length);
+        toFire.forEach((cb) => cb(ctx));
       },
     };
   }
@@ -422,6 +457,49 @@ describe('applyOrchestrate — reactive (deferred) sessionProjections (P0 timing
     expect(fake.registeredSections[0].text({ agent: { session: { id: 's1' } } })).toBe('');
     fake.mountSessionProjections();
     expect(fake.registeredSections[0].text({ agent: { session: { id: 's1' } } })).toContain('PURE ORCHESTRATOR');
+  });
+});
+
+describe('plugin entry — inject contract (blocker #1: commands service declared)', () => {
+  it('declares the commands service in inject so cordis can satisfy it before apply', () => {
+    expect(pluginName).toBe('subagent-director');
+    // The headless/web host mounts `commands`; declaring it in inject makes the
+    // dependency explicit (cordis required-service semantics) instead of a
+    // silent ctx.get that no-ops on hosts where it mounts late.
+    expect(pluginInject).toContain('commands');
+    expect(pluginInject).toContain('tools');
+    expect(pluginInject).toContain('subagents');
+    expect(pluginInject).toContain('llm');
+    expect(pluginInject).toContain('settings');
+  });
+});
+
+describe('applyOrchestrate — command registration is reactive (delayed commands service)', () => {
+  // Pins the blocker #1 fix: the /orchestrate command is registered through
+  // ctx.inject, so it appears only once the `commands` service is ready — not
+  // via a one-shot ctx.get guard that silently no-ops.
+  it('does not register until the commands service becomes available, then registers', () => {
+    const { ctx, registeredCommands, mountCommands } = makeFakeCtx({ withoutCommands: true });
+    applyOrchestrate(ctx, getSettings, toolName);
+    // At apply time the commands service is absent — no command registered yet.
+    expect(registeredCommands).toHaveLength(0);
+    // Host mounts the commands service later → the ctx.inject callback fires.
+    mountCommands();
+    expect(registeredCommands).toHaveLength(1);
+    expect(registeredCommands[0].name).toBe('orchestrate');
+  });
+
+  it('command handler works after the commands service arrives (full happy path)', () => {
+    const { ctx, registeredCommands, mountCommands, logger } = makeFakeCtx({ withoutCommands: true });
+    applyOrchestrate(ctx, getSettings, toolName);
+    mountCommands();
+    const handler = registeredCommands[0].handler;
+    const appended: any[] = [];
+    const res = handler({ rawInput: 'on', agent: { session: { append: (t: string, d: any) => appended.push([t, d]) } } });
+    expect(res.kind).toBe('success');
+    expect(res.text).toContain('on');
+    expect(appended).toEqual([[ORCHESTRATE_EVENT_TYPE, { mode: 'on' }]]);
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/test/orchestrate-wiring.test.ts
+++ b/test/orchestrate-wiring.test.ts
@@ -3,9 +3,10 @@
  *
  * Pins the real host contracts discovered in @deepseek-ai/dsh-session-projection
  * and @deepseek-ai/dsh-system-prompt:
- *  - the projection `register` definition MUST carry a `schema` (the framework
- *    calls `schema.parse(view(state))` on every snapshot; without it the
- *    section silently fails to inject — the D1 root cause);
+ *  - the projection `register` definition MUST carry `stateSchema` (host-state
+ *    validation) AND `wire: { viewSchema, view }`; without `wire` the unit is
+ *    host-only and `snapshot()` skips it, so the section silently fails to
+ *    inject (the actual root cause — the prior `schema`+bare-`view` mock hid it);
  *  - the system-prompt section `text(context)` receives an AssembleContext that
  *    carries `agent` at runtime (dsh-agent assembleContextFor), and must also
  *    accept a bare `context.session` (D2 fallback);
@@ -54,8 +55,14 @@ function makeFakeCtx(opts: { withoutProjections?: boolean; identityKeyed?: boole
     },
     snapshot(sessionArg: any) {
       if (state.throws) throw new Error('forced snapshot failure');
+      // Faithful mirror of SessionProjectionRegistry.snapshot: client-visible
+      // units (with `wire`) appear in values; host-only units (no `wire`) are
+      // skipped — the real root-cause skip that hid the bug.
+      if (!projectionDef || projectionDef.wire === undefined) {
+        return { asOfSeq: -1, values: {} };
+      }
       if (!opts.identityKeyed) {
-        return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: { mode: state.mode } } };
+        return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: projectionDef.wire.viewSchema.parse(projectionDef.wire.view({ mode: state.mode })) } };
       }
       let cell = cells.get(sessionArg);
       if (!cell) {
@@ -65,7 +72,7 @@ function makeFakeCtx(opts: { withoutProjections?: boolean; identityKeyed?: boole
         }
         cells.set(sessionArg, cell);
       }
-      const value = projectionDef.schema.parse(projectionDef.view({ mode: cell.mode }));
+      const value = projectionDef.wire.viewSchema.parse(projectionDef.wire.view({ mode: cell.mode }));
       return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: value } };
     },
   };
@@ -185,10 +192,14 @@ describe('applyOrchestrate — projection register', () => {
     const def = getProjectionDef();
     expect(def).toBeDefined();
     expect(def.key).toBe(ORCHESTRATE_PROJECTION_KEY);
-    expect(typeof def.schema?.parse).toBe('function');
-    // the schema validates the view output the framework re-parses on snapshot
-    expect(def.schema.parse({ mode: 'on' })).toEqual({ mode: 'on' });
-    expect(() => def.schema.parse({ mode: 'bad' })).toThrow();
+    // Real contract: host-state validation lives in `stateSchema`; the
+    // client-visible unit MUST also declare `wire: { viewSchema, view }`.
+    expect(typeof def.stateSchema?.parse).toBe('function');
+    expect(def.stateSchema.parse({ mode: 'on' })).toEqual({ mode: 'on' });
+    expect(() => def.stateSchema.parse({ mode: 'bad' })).toThrow();
+    expect(typeof def.wire?.viewSchema?.parse).toBe('function');
+    expect(def.wire.viewSchema.parse({ mode: 'on' })).toEqual({ mode: 'on' });
+    expect(() => def.wire.viewSchema.parse({ mode: 'bad' })).toThrow();
   });
 
   it('apply folds the orchestrate/change event into the mode state', () => {
@@ -334,7 +345,10 @@ describe('applyOrchestrate — reactive (deferred) sessionProjections (P0 timing
       },
       snapshot(_session: any) {
         if (state.throws) throw new Error('forced snapshot failure');
-        return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: { mode: state.mode } } };
+        if (!projectionDef || projectionDef.wire === undefined) {
+          return { asOfSeq: -1, values: {} };
+        }
+        return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: projectionDef.wire.viewSchema.parse(projectionDef.wire.view({ mode: state.mode })) } };
       },
     };
     const systemPrompt = { section(def: any) { registeredSections.push(def); return () => {}; } };
@@ -379,7 +393,7 @@ describe('applyOrchestrate — reactive (deferred) sessionProjections (P0 timing
     fake.mountSessionProjections();
     expect(fake.getProjectionDef()).toBeDefined();
     expect(fake.getProjectionDef().key).toBe(ORCHESTRATE_PROJECTION_KEY);
-    expect(typeof fake.getProjectionDef().schema?.parse).toBe('function');
+    expect(typeof fake.getProjectionDef().wire?.viewSchema?.parse).toBe('function');
   });
 
   it('returns an honest error before the service is ready, success after', () => {

--- a/test/orchestrate-wiring.test.ts
+++ b/test/orchestrate-wiring.test.ts
@@ -29,20 +29,44 @@ const settings = {
 const getSettings = () => settings;
 const toolName = 'subagent_role';
 
-function makeFakeCtx(opts: { withoutProjections?: boolean } = {}) {
+function makeFakeCtx(opts: { withoutProjections?: boolean; identityKeyed?: boolean } = {}) {
   const state = { mode: 'off' as string, throws: false };
   const registeredSections: any[] = [];
   const registeredCommands: any[] = [];
   let projectionDef: any = undefined;
+  // Mirrors @deepseek-ai/dsh-session-projection's real WeakMap keyed by the
+  // session OBJECT (cellFor reads registration.cells.get(session) and folds
+  // session.events). When identityKeyed, snapshot() resolves the mode from the
+  // candidate session's own event log, so a DIFFERENT session object yields the
+  // init default 'off' — reproducing the render-time silent no-op exactly.
+  const cells = new WeakMap<any, { mode: string }>();
 
   const sessionProjections = {
     register(def: any) {
       projectionDef = def;
       return () => {};
     },
-    snapshot(_session: any) {
+    // Simulate the command appending an event into a (render- or command-time)
+    // session's log, exactly as invocation.agent.session.append does at runtime.
+    appendEvent(sessionArg: any, type: string, data: any) {
+      sessionArg.events = sessionArg.events || [];
+      sessionArg.events.push({ type, data });
+    },
+    snapshot(sessionArg: any) {
       if (state.throws) throw new Error('forced snapshot failure');
-      return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: { mode: state.mode } } };
+      if (!opts.identityKeyed) {
+        return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: { mode: state.mode } } };
+      }
+      let cell = cells.get(sessionArg);
+      if (!cell) {
+        cell = { mode: projectionDef.init().mode };
+        if (sessionArg && Array.isArray(sessionArg.events)) {
+          for (const ev of sessionArg.events) cell.mode = projectionDef.apply({ mode: cell.mode }, ev).mode;
+        }
+        cells.set(sessionArg, cell);
+      }
+      const value = projectionDef.schema.parse(projectionDef.view({ mode: cell.mode }));
+      return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: value } };
     },
   };
   const systemPrompt = {
@@ -86,6 +110,73 @@ function makeFakeCtx(opts: { withoutProjections?: boolean } = {}) {
     logger,
   };
 }
+
+describe('applyOrchestrate — render path (session-identity resolution)', () => {
+  // These cases use an identity-keyed fake whose snapshot() folds the candidate
+  // session's own event log, mirroring the real WeakMap-backed registry. They
+  // pin the P0 render-time fix: the section must resolve the mode from a stable
+  // session reference (on wins across candidate references) and must NEVER
+  // silently return '' when the mode cannot be resolved.
+  function buildOnSessions() {
+    const fake = makeFakeCtx({ identityKeyed: true });
+    applyOrchestrate(fake.ctx, getSettings, toolName);
+    const cmdSession = { id: 'cmd-session', events: [] };
+    // Simulate /orchestrate on: command appends the event to cmdSession's log.
+    fake.sessionProjections.appendEvent(cmdSession, ORCHESTRATE_EVENT_TYPE, { mode: 'on' });
+    return { fake, cmdSession };
+  }
+
+  it('injects when the render agent.session is the same object that received the event', () => {
+    const { fake, cmdSession } = buildOnSessions();
+    const text = fake.registeredSections[0].text({ agent: { session: cmdSession } });
+    expect(text).toContain('PURE ORCHESTRATOR');
+  });
+
+  it('injects even when a stray wrong context.session reference co-exists (on wins across candidates)', () => {
+    const { fake, cmdSession } = buildOnSessions();
+    const wrongSession = { id: 'wrong-session', events: [] };
+    const text = fake.registeredSections[0].text({ agent: { session: cmdSession }, session: wrongSession });
+    expect(text).toContain('PURE ORCHESTRATOR');
+  });
+
+  it('injects regardless of candidate order when the correct session is the bare context.session', () => {
+    const { fake, cmdSession } = buildOnSessions();
+    const wrongSession = { id: 'wrong-session', events: [] };
+    const text = fake.registeredSections[0].text({ session: wrongSession, agent: { session: cmdSession } });
+    expect(text).toContain('PURE ORCHESTRATOR');
+  });
+
+  it('does NOT inject and does NOT warn when mode is legitimately off (resolved from the event log)', () => {
+    const fake = makeFakeCtx({ identityKeyed: true });
+    applyOrchestrate(fake.ctx, getSettings, toolName);
+    const offSession = { id: 'off-session', events: [] };
+    fake.sessionProjections.appendEvent(offSession, ORCHESTRATE_EVENT_TYPE, { mode: 'off' });
+    const text = fake.registeredSections[0].text({ agent: { session: offSession } });
+    expect(text).toBe('');
+    expect(fake.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns (no silent drop) when no session is resolvable from the context', () => {
+    const { fake } = buildOnSessions();
+    const text = fake.registeredSections[0].text({});
+    expect(text).toBe('');
+    expect(fake.logger.warn).toHaveBeenCalled();
+    const msg = String(fake.logger.warn.mock.calls.at(-1)?.[0]);
+    expect(msg).toContain('[orchestrate]');
+    expect(msg).toMatch(/session|context|skipped/i);
+  });
+
+  it('warns (no silent drop) when the render session identity never received the event', () => {
+    const { fake, cmdSession } = buildOnSessions();
+    // Render with a DIFFERENT session object that has no orchestrate/change log.
+    const stranger = { id: 'stranger', events: [] };
+    const text = fake.registeredSections[0].text({ agent: { session: stranger } });
+    expect(text).toBe('');
+    // cmdSession still holds 'on'; the section should NOT silently pretend off.
+    const cmdText = fake.registeredSections[0].text({ agent: { session: cmdSession } });
+    expect(cmdText).toContain('PURE ORCHESTRATOR');
+  });
+});
 
 describe('applyOrchestrate — projection register', () => {
   it('registers a definition that includes a schema (snapshot contract)', () => {

--- a/test/orchestrate-wiring.test.ts
+++ b/test/orchestrate-wiring.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for the /orchestrate wiring in applyOrchestrate.
+ *
+ * Pins the real host contracts discovered in @deepseek-ai/dsh-session-projection
+ * and @deepseek-ai/dsh-system-prompt:
+ *  - the projection `register` definition MUST carry a `schema` (the framework
+ *    calls `schema.parse(view(state))` on every snapshot; without it the
+ *    section silently fails to inject — the D1 root cause);
+ *  - the system-prompt section `text(context)` receives an AssembleContext that
+ *    carries `agent` at runtime (dsh-agent assembleContextFor), and must also
+ *    accept a bare `context.session` (D2 fallback);
+ *  - the command handler defaults to "on" with no args, accepts on/off, rejects
+ *    invalid input, and appends the orchestrate/change event;
+ *  - the orchestrate/change event type registers idempotently.
+ *
+ * Uses fake host services so no real Cordis/Session is required.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  applyOrchestrate,
+  ORCHESTRATE_PROJECTION_KEY,
+  ORCHESTRATE_EVENT_TYPE,
+} from '../src/orchestrate.js';
+import { KNOWN_SESSION_EVENT_TYPES } from '@deepseek-ai/dsh-session';
+
+const settings = {
+  roles: { dev: { displayName: 'Dev', description: 'd', provider: 'p', model: 'm' } },
+};
+const getSettings = () => settings;
+const toolName = 'subagent_role';
+
+function makeFakeCtx() {
+  const state = { mode: 'off' as string, throws: false };
+  const registeredSections: any[] = [];
+  const registeredCommands: any[] = [];
+  let projectionDef: any = undefined;
+
+  const sessionProjections = {
+    register(def: any) {
+      projectionDef = def;
+      return () => {};
+    },
+    snapshot(_session: any) {
+      if (state.throws) throw new Error('forced snapshot failure');
+      return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: { mode: state.mode } } };
+    },
+  };
+  const systemPrompt = {
+    section(def: any) {
+      registeredSections.push(def);
+      return () => {};
+    },
+  };
+  const commands = {
+    register(def: any) {
+      registeredCommands.push(def);
+      return () => {};
+    },
+  };
+  const logger = { info: vi.fn(), warn: vi.fn() };
+  const ctx: any = {
+    logger,
+    get(name: string) {
+      if (name === 'sessionProjections') return sessionProjections;
+      if (name === 'systemPrompt') return systemPrompt;
+      if (name === 'commands') return commands;
+      return undefined;
+    },
+  };
+  return {
+    ctx,
+    registeredSections,
+    registeredCommands,
+    getProjectionDef: () => projectionDef,
+    sessionProjections,
+    state,
+    logger,
+  };
+}
+
+describe('applyOrchestrate — projection register', () => {
+  it('registers a definition that includes a schema (snapshot contract)', () => {
+    const { ctx, getProjectionDef } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    const def = getProjectionDef();
+    expect(def).toBeDefined();
+    expect(def.key).toBe(ORCHESTRATE_PROJECTION_KEY);
+    expect(typeof def.schema?.parse).toBe('function');
+    // the schema validates the view output the framework re-parses on snapshot
+    expect(def.schema.parse({ mode: 'on' })).toEqual({ mode: 'on' });
+    expect(() => def.schema.parse({ mode: 'bad' })).toThrow();
+  });
+
+  it('apply folds the orchestrate/change event into the mode state', () => {
+    const { ctx, getProjectionDef } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    const def = getProjectionDef();
+    expect(def.apply({ mode: 'off' }, { type: ORCHESTRATE_EVENT_TYPE, data: { mode: 'on' } })).toEqual({ mode: 'on' });
+    // unrelated events leave state untouched
+    expect(def.apply({ mode: 'on' }, { type: 'other', data: {} })).toEqual({ mode: 'on' });
+    // invalid mode leaves state untouched
+    expect(def.apply({ mode: 'off' }, { type: ORCHESTRATE_EVENT_TYPE, data: { mode: 'nope' } })).toEqual({ mode: 'off' });
+  });
+});
+
+describe('applyOrchestrate — system-prompt section', () => {
+  it('injects the orchestrator prompt when mode is on (context.agent.session)', () => {
+    const { ctx, state, registeredSections } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    state.mode = 'on';
+    const text = registeredSections[0].text({ agent: { session: { id: 's1' } } });
+    expect(text).toContain('PURE ORCHESTRATOR');
+    expect(text).toContain('subagent_role');
+  });
+
+  it('does not inject when mode is off', () => {
+    const { ctx, state, registeredSections } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    state.mode = 'off';
+    expect(registeredSections[0].text({ agent: { session: { id: 's1' } } })).toBe('');
+  });
+
+  it('falls back to context.session when context.agent is absent (D2)', () => {
+    const { ctx, state, registeredSections } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    state.mode = 'on';
+    const text = registeredSections[0].text({ session: { id: 's2' } });
+    expect(text).toContain('PURE ORCHESTRATOR');
+  });
+
+  it('returns empty when neither context.session nor context.agent.session exists', () => {
+    const { ctx, state, registeredSections } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    state.mode = 'on';
+    expect(registeredSections[0].text({})).toBe('');
+    expect(registeredSections[0].text(undefined)).toBe('');
+  });
+
+  it('logs a warning instead of silently dropping the prompt when snapshot throws (D1)', () => {
+    const { ctx, state, registeredSections, logger } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    state.mode = 'on';
+    state.throws = true;
+    const text = registeredSections[0].text({ agent: { session: { id: 's1' } } });
+    expect(text).toBe(''); // safe fallback to off
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(String(logger.warn.mock.calls[0][0])).toContain('[orchestrate]');
+  });
+});
+
+describe('applyOrchestrate — command handler', () => {
+  it('defaults to on with no args and appends the event', () => {
+    const { ctx, registeredCommands } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    const handler = registeredCommands[0].handler;
+    const appended: any[] = [];
+    const res = handler({
+      rawInput: '',
+      agent: { session: { append: (t: string, d: any) => appended.push([t, d]) } },
+    });
+    expect(res.kind).toBe('success');
+    expect(res.text).toContain('on');
+    expect(appended).toEqual([[ORCHESTRATE_EVENT_TYPE, { mode: 'on' }]]);
+  });
+
+  it('accepts off and rejects invalid input', () => {
+    const { ctx, registeredCommands } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    const handler = registeredCommands[0].handler;
+    const off = handler({ rawInput: 'off', agent: { session: { append: () => {} } } });
+    expect(off.kind).toBe('success');
+    expect(off.text).toContain('off');
+    const bad = handler({ rawInput: 'maybe', agent: { session: { append: () => {} } } });
+    expect(bad.kind).toBe('error');
+    expect(bad.text).toContain('Valid: on|off');
+  });
+});
+
+describe('applyOrchestrate — event registration', () => {
+  it('registers orchestrate/change idempotently across multiple applies', () => {
+    const { ctx } = makeFakeCtx();
+    applyOrchestrate(ctx, getSettings, toolName);
+    applyOrchestrate(ctx, getSettings, toolName);
+    expect(KNOWN_SESSION_EVENT_TYPES.has(ORCHESTRATE_EVENT_TYPE)).toBe(true);
+  });
+});

--- a/test/orchestrate-wiring.test.ts
+++ b/test/orchestrate-wiring.test.ts
@@ -222,3 +222,101 @@ describe('applyOrchestrate — event registration', () => {
     expect(KNOWN_SESSION_EVENT_TYPES.has(ORCHESTRATE_EVENT_TYPE)).toBe(true);
   });
 });
+
+describe('applyOrchestrate — reactive (deferred) sessionProjections (P0 timing fix)', () => {
+  // Simulates a host where sessionProjections is absent at apply time but the
+  // ctx.inject callback fires once the host mounts the service *later*. Mirrors
+  // the cordis ctx.inject contract: callback runs with an injected ctx once the
+  // dependency is present, and returns a disposable fiber.
+  function makeFakeCtxDeferred() {
+    const state = { mode: 'off' as string, throws: false };
+    const registeredSections: any[] = [];
+    const registeredCommands: any[] = [];
+    let projectionDef: any = undefined;
+    let mounted = false;
+    let injectCb: ((ctx: any) => void) | undefined;
+
+    const sessionProjections = {
+      register(def: any) {
+        projectionDef = def;
+        return () => {};
+      },
+      snapshot(_session: any) {
+        if (state.throws) throw new Error('forced snapshot failure');
+        return { asOfSeq: -1, values: { [ORCHESTRATE_PROJECTION_KEY]: { mode: state.mode } } };
+      },
+    };
+    const systemPrompt = { section(def: any) { registeredSections.push(def); return () => {}; } };
+    const commands = { register(def: any) { registeredCommands.push(def); return () => {}; } };
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const ctx: any = {
+      logger,
+      get(name: string) {
+        if (name === 'sessionProjections') return mounted ? sessionProjections : undefined;
+        if (name === 'systemPrompt') return systemPrompt;
+        if (name === 'commands') return commands;
+        return undefined;
+      },
+      inject(_deps: string[], cb: (ctx: any) => void) {
+        injectCb = cb;
+        return { dispose: () => { injectCb = undefined; } };
+      },
+      effect: () => () => {},
+    };
+    return {
+      ctx,
+      registeredSections,
+      registeredCommands,
+      getProjectionDef: () => projectionDef,
+      state,
+      logger,
+      // Simulate the host mounting the service after apply time.
+      mountSessionProjections: () => {
+        mounted = true;
+        injectCb?.(ctx);
+      },
+    };
+  }
+
+  it('does not register the projection until the service becomes available', () => {
+    const fake = makeFakeCtxDeferred();
+    applyOrchestrate(fake.ctx, getSettings, toolName);
+    // Service absent at apply time → no projection yet, no false warning.
+    expect(fake.getProjectionDef()).toBeUndefined();
+    expect(fake.logger.warn).not.toHaveBeenCalled();
+    // Host mounts the service later → inject callback registers it.
+    fake.mountSessionProjections();
+    expect(fake.getProjectionDef()).toBeDefined();
+    expect(fake.getProjectionDef().key).toBe(ORCHESTRATE_PROJECTION_KEY);
+    expect(typeof fake.getProjectionDef().schema?.parse).toBe('function');
+  });
+
+  it('returns an honest error before the service is ready, success after', () => {
+    const fake = makeFakeCtxDeferred();
+    applyOrchestrate(fake.ctx, getSettings, toolName);
+    const handler = fake.registeredCommands[0].handler;
+    const before = handler({ rawInput: 'on', agent: { session: { append: () => {} } } });
+    expect(before.kind).toBe('error');
+    expect(before.text).toMatch(/NOT applied|missing|will NOT take effect/i);
+    fake.mountSessionProjections();
+    const appended: any[] = [];
+    const after = handler({
+      rawInput: 'on',
+      agent: { session: { append: (t: string, d: any) => appended.push([t, d]) } },
+    });
+    expect(after.kind).toBe('success');
+    expect(after.text).toContain('on');
+    expect(appended).toEqual([[ORCHESTRATE_EVENT_TYPE, { mode: 'on' }]]);
+  });
+
+  it('injects the orchestrator prompt only after the projection is registered', () => {
+    const fake = makeFakeCtxDeferred();
+    applyOrchestrate(fake.ctx, getSettings, toolName);
+    fake.state.mode = 'on';
+    // Before the service mounts, the section cannot read the projection.
+    expect(fake.registeredSections[0].text({ agent: { session: { id: 's1' } } })).toBe('');
+    fake.mountSessionProjections();
+    expect(fake.registeredSections[0].text({ agent: { session: { id: 's1' } } })).toContain('PURE ORCHESTRATOR');
+  });
+});
+

--- a/test/orchestrate.test.ts
+++ b/test/orchestrate.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the orchestrate prompt renderer (merged /orchestrate command).
+ * Covers: dynamic role rendering from settings, the empty-roles notice, and
+ * that the coordinator reference is generalized (never hard-codes a role id).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  renderOrchestratorRoles,
+  renderOrchestratorPrompt,
+  buildOrchestratorFrame,
+  ORCHESTRATE_VALID_MODES,
+} from '../src/orchestrate.js';
+
+const settings = {
+  roles: {
+    'dev-role': {
+      displayName: '开发工程师',
+      description: '实现功能代码',
+      provider: 'opencode-go',
+      model: 'mimo-v2.5',
+    },
+    'coord-role': {
+      displayName: '项目协调者',
+      description: '分解与协调任务',
+      provider: 'opencode-go',
+      model: 'mimo-v2.5',
+    },
+  },
+};
+
+describe('renderOrchestratorRoles', () => {
+  it('tells the user to configure roles when none are set', () => {
+    const text = renderOrchestratorRoles({}, 'subagent_role');
+    expect(text).toContain('No Subagent Director roles are configured');
+    expect(text).toContain('subagent-director.roles');
+  });
+
+  it('lists each configured role by id with its delegate line', () => {
+    const text = renderOrchestratorRoles(settings, 'subagent_role');
+    expect(text).toContain('subagent_role({ role: "dev-role", prompt: "..." })');
+    expect(text).toContain('开发工程师');
+    expect(text).toContain('项目协调者');
+  });
+
+  it('never hard-codes a specific coordinator role id', () => {
+    const text = renderOrchestratorPrompt(settings, 'subagent_role');
+    expect(text).not.toMatch(/\brole-3\b/);
+    // Coordinator is referenced by display-name semantics, not a literal id.
+    expect(text).toMatch(/协调|Orchestrator|Coordinator/);
+  });
+});
+
+describe('renderOrchestratorPrompt', () => {
+  it('uses the configured tool name, not a hard-coded one', () => {
+    const text = renderOrchestratorPrompt(settings, 'my_role_tool');
+    expect(text).toContain('my_role_tool({ role: "dev-role", prompt: "..." })');
+    expect(text).not.toContain('subagent_role({ role: "dev-role"');
+  });
+
+  it('injects the empty-roles notice when settings have no roles', () => {
+    const text = renderOrchestratorPrompt({}, 'subagent_role');
+    expect(text).toContain('No Subagent Director roles are configured');
+  });
+});
+
+describe('buildOrchestratorFrame', () => {
+  it('substitutes the tool name into the framing', () => {
+    expect(buildOrchestratorFrame('dispatch')).toContain('`dispatch` tool');
+  });
+});
+
+describe('ORCHESTRATE_VALID_MODES', () => {
+  it('accepts only on/off', () => {
+    expect(ORCHESTRATE_VALID_MODES).toEqual(['on', 'off']);
+  });
+});


### PR DESCRIPTION
## 动机
将独立 orchestrate 插件的功能并入 subagent-director，使"纯编排模式"复用插件自身的角色模板（settings.subagent-director.roles），避免硬编码 7 个 role id，与插件"模板即数据"设计一致。

## 改动清单
- inject 增加 'commands'；新增 src/orchestrate.ts（/orchestrate on|off 命令 + 'orchestrate' session projection + 'orchestrate/change' 事件 + order 55 的 orchestrator-mode systemPrompt section）。
- role 清单动态从插件 settings 渲染，空时提示先配置；协调者引用泛化；补 zod schema 修复 projection snapshot 静默失败。
- 复用 @deepseek-ai/dsh-session 的 KNOWN_SESSION_EVENT_TYPES（新增 peerDependency rc.6）；支持 context.session / context.agent.session 两种形状。
- 各 host-plane 服务可选 + undefined 守卫，缺失 no-op。
- 新增 test/orchestrate.test.ts（7 例）与 test/orchestrate-wiring.test.ts（10 例）。

## 测试结果
pnpm test：214 passed / 0 failed（上游用例全绿 + 新增 17 个编排用例）。
注：typecheck/build 现有一处与本次无关的预存错误（src/settings.ts TS2883，cosmokit 1.8.2 漂移所致），本 PR 未改动 settings.ts。

## 与 0.2.1 / 0.3.0 的关系
基于 v0.3.0（main @ 77c8ed0）开发；本地安装版 0.2.1 不受影响。